### PR TITLE
deps: update dependency axios to v1.9.0

### DIFF
--- a/plainly-plugin/package.json
+++ b/plainly-plugin/package.json
@@ -17,7 +17,7 @@
     "@heroicons/react": "^2.1.5",
     "@tanstack/react-query": "^5.66.0",
     "archiver": "^5.3.2",
-    "axios": "^1.7.9",
+    "axios": "^1.9.0",
     "classnames": "^2.5.1",
     "date-fns": "^4.1.0",
     "form-data": "^4.0.1",

--- a/plainly-plugin/yarn.lock
+++ b/plainly-plugin/yarn.lock
@@ -1515,10 +1515,10 @@ autoprefixer@^10.4.20:
     picocolors "^1.0.1"
     postcss-value-parser "^4.2.0"
 
-axios@^1.7.9:
-  version "1.7.9"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.9.tgz#d7d071380c132a24accda1b2cfc1535b79ec650a"
-  integrity sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==
+axios@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.9.0.tgz#25534e3b72b54540077d33046f77e3b8d7081901"
+  integrity sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==
   dependencies:
     follow-redirects "^1.15.6"
     form-data "^4.0.0"


### PR DESCRIPTION
Original issue: https://github.com/plainly-videos/after-effects-plugin/security/dependabot/4
