### PR TITLE
Skip relink for PSD files

### DIFF
--- a/plainly-aescripts/src/relink.ts
+++ b/plainly-aescripts/src/relink.ts
@@ -17,8 +17,11 @@ function relinkFootage(relinkData: RelinkData): void {
       continue;
     }
 
-    // Important: Skip PSD files
-    if (originalFile.fsName.endsWith('.psd')) {
+    // Important: Skip PSD (Photoshop) and AI (illustrator) files
+    if (
+      originalFile.fsName.endsWith('.psd') ||
+      originalFile.fsName.endsWith('.ai')
+    ) {
       continue;
     }
 


### PR DESCRIPTION
**Problem**

PSD / AI layers can be imported to the AE projects in different ways. One way is to import it as a separate layers, but all layers are referencing the same PSD / AI file. 
Our relinking logic is just doing a standard replace file, so the PSD / AI is being "reimported" as a whole image (not its separate layers) and everything gets f*cked up...

**Solution**

Skip relinking files that ends with PSD / AI (AE requires files to have a valid file extension). 
If the project already has a good structure (using (Footage) etc), everything should work fine.
If the project is not linked properly and has PSD / AI imported in a way mentioned above, the project won't be correctly linked.
