### PR TITLE
fix(deps): update dependency axios to 1.13.5 [security]

### DIFF
--- a/plainly-plugin/package.json
+++ b/plainly-plugin/package.json
@@ -17,7 +17,7 @@
     "@heroicons/react": "^2.1.5",
     "@tanstack/react-query": "^5.66.0",
     "archiver": "^5.3.2",
-    "axios": "^1.12.2",
+    "axios": "^1.13.5",
     "classnames": "^2.5.1",
     "date-fns": "^4.1.0",
     "form-data": "^4.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3202,14 +3202,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.12.2":
-  version: 1.13.2
-  resolution: "axios@npm:1.13.2"
+"axios@npm:^1.13.5":
+  version: 1.13.5
+  resolution: "axios@npm:1.13.5"
   dependencies:
-    follow-redirects: ^1.15.6
-    form-data: ^4.0.4
+    follow-redirects: ^1.15.11
+    form-data: ^4.0.5
     proxy-from-env: ^1.1.0
-  checksum: 057d0204d5930e2969f0bccb9f0752745b1524a36994667833195e7e1a82f245d660752ba8517b2dbea17e9e4ed0479f10b80c5fe45edd0b5a0df645c0060386
+  checksum: 985024c4a32f837053f198f02a308fd6f8bfb4053a2f21e39e37992bc6d06917f008679c36b3e7f0f0c9060c85ffe37c61e58d2ac662595d68dc1b89cef78de8
   languageName: node
   linkType: hard
 
@@ -4475,7 +4475,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.15.6":
+"follow-redirects@npm:^1.15.11":
   version: 1.15.11
   resolution: "follow-redirects@npm:1.15.11"
   peerDependenciesMeta:
@@ -4495,7 +4495,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data@npm:^4.0.4":
+"form-data@npm:^4.0.4, form-data@npm:^4.0.5":
   version: 4.0.5
   resolution: "form-data@npm:4.0.5"
   dependencies:
@@ -6492,7 +6492,7 @@ __metadata:
     "@types/react-dom": ^18.3.1
     archiver: ^5.3.2
     autoprefixer: ^10.4.20
-    axios: ^1.12.2
+    axios: ^1.13.5
     babel-jest: ^30.2.0
     babel-loader: ^9.2.1
     classnames: ^2.5.1


### PR DESCRIPTION
Issue: https://github.com/plainly-videos/after-effects-plugin/security/dependabot/25

Works:

<img width="471" height="104" alt="image" src="https://github.com/user-attachments/assets/779566ab-47a4-4b6f-bb57-fdbbe4dc0fc9" />
