### PR TITLE
fix: missing zip destionation error not displayed in UI notification

### DIFF
--- a/plainly-plugin/src/node/utils.ts
+++ b/plainly-plugin/src/node/utils.ts
@@ -130,8 +130,17 @@ export const zipItems = async (
 
     output.on('close', () => resolve(outputZipPath));
 
+    output.on('error', (err) => {
+      archive.destroy();
+      reject(err);
+    });
+
     archive.on('error', (err) => {
-      fs.unlinkSync(outputZipPath);
+      try {
+        fs.unlinkSync(outputZipPath);
+      } catch {
+        // Ignore cleanup errors
+      }
       reject(err);
     });
 
@@ -147,7 +156,9 @@ export const zipItems = async (
         }
       } catch (error) {
         if (item.isRequired) {
-          throw error;
+          archive.destroy();
+          reject(error);
+          return;
         }
       }
     }


### PR DESCRIPTION
if target path is missing, error is displayed in console, but UI shows success message, even tho nothing happens

To manually reporduce:

1. select folder for Export
2. remove folder from the machine
3. click Export button