### PR TITLE
closes #145: update CI actions, uses latest node version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Cache turbo build setup
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .turbo
           key: ${{ runner.os }}-turbo-${{ github.sha }}
@@ -23,9 +23,6 @@ jobs:
 
       - name: Install Node.js
         uses: actions/setup-node@v6
-        with:
-          node-version: '20.11.1'
-          cache: 'yarn'
 
       - name: Install dependencies
         run: yarn install --immutable
@@ -47,7 +44,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Cache turbo build setup
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .turbo
           key: ${{ runner.os }}-turbo-${{ github.sha }}
@@ -55,9 +52,6 @@ jobs:
 
       - name: Install Node.js
         uses: actions/setup-node@v6
-        with:
-          node-version: '20.11.1'
-          cache: 'yarn'
 
       - name: Install dependencies
         run: yarn install --immutable
@@ -74,7 +68,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Cache turbo build setup
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .turbo
           key: ${{ runner.os }}-turbo-${{ github.sha }}
@@ -82,9 +76,6 @@ jobs:
 
       - name: Install Node.js
         uses: actions/setup-node@v6
-        with:
-          node-version: '20.11.1'
-          cache: 'yarn'
 
       - name: Install dependencies
         run: yarn install --immutable

--- a/.github/workflows/sign-extension.yml
+++ b/.github/workflows/sign-extension.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Cache turbo build setup
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .turbo
           key: ${{ runner.os }}-turbo-${{ github.sha }}
@@ -22,9 +22,6 @@ jobs:
 
       - name: Install Node.js
         uses: actions/setup-node@v6
-        with:
-          node-version: '20.11.1'
-          cache: 'yarn'
 
       - name: Install dependencies
         run: yarn install --immutable
@@ -62,7 +59,7 @@ jobs:
             -tsa http://timestamp.apple.com/ts01
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: plainly-plugin
           path: plainly-plugin.zxp


### PR DESCRIPTION
## Summary

<!-- What does this PR do? 1-3 sentences. -->

Updates CI, removes old node-versions, and lets node use lts by default.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / internal improvement
- [ ] Dependency update
- [x] Docs / tooling

## Related issue

#145 

## Testing

<!-- How was this tested? Check all that apply. -->

- [ ] Tested manually in After Effects
- [ ] Unit tests added / updated
- [ ] Existing tests pass (`yarn test`)

**After Effects version tested:**
**OS tested on:**

## Screenshots

<!-- If this changes the UI, include before/after screenshots. -->

## Checklist

- [ ] `yarn biome` passes (or `yarn biome:fix` was run)
- [ ] `yarn build` completes without errors
- [ ] No new TypeScript errors
