### PR TITLE
Layout improvements

### DIFF
--- a/plainly-plugin/package.json
+++ b/plainly-plugin/package.json
@@ -13,6 +13,7 @@
     "test:ci:coverage": "jest --ci --coverage"
   },
   "dependencies": {
+    "@base-ui/react": "^1.3.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^8.0.0",
     "@headlessui/react": "^2.2.0",
@@ -21,6 +22,7 @@
     "archiver": "^5.3.2",
     "axios": "^1.13.5",
     "classnames": "^2.5.1",
+    "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "form-data": "^4.0.4",
     "lodash-es": "^4.17.23",
@@ -28,7 +30,8 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-hooks-global-state": "^2.1.0",
-    "semver": "^7.7.4"
+    "semver": "^7.7.4",
+    "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {
     "@babel/core": "^7.28.6",

--- a/plainly-plugin/src/ui/App.tsx
+++ b/plainly-plugin/src/ui/App.tsx
@@ -1,6 +1,12 @@
 import { isDev, pluginBundleVersion } from '@src/env';
 import { useMemo } from 'react';
-import { Banner, Button, ExternalLink, Sidebar } from './components';
+import {
+  Banner,
+  Button,
+  ExternalLink,
+  Sidebar,
+  TooltipProvider,
+} from './components';
 import { useGetLatestGithubRelease, useNavigate } from './hooks';
 import {
   AboutRoute,
@@ -45,24 +51,26 @@ export function App() {
           Reload extension
         </Button>
       )}
-      <Sidebar />
-      <Banner show={showBanner}>
-        <p className="text-white text-xs font-medium">
-          A new version is available! 🚀 See{' '}
-          <ExternalLink
-            to={`https://github.com/plainly-videos/after-effects-plugin/releases/tag/${data?.tag_name}`}
-            text="what's new"
-          />{' '}
-          and{' '}
-          <ExternalLink
-            to="https://exchange.adobe.com/apps/cc/202811/plainly-videos"
-            text="upgrade"
-          />
-          .
-        </p>
-      </Banner>
+      <TooltipProvider>
+        <Sidebar />
+        <Banner show={showBanner}>
+          <p className="text-white text-xs font-medium">
+            A new version is available! 🚀 See{' '}
+            <ExternalLink
+              to={`https://github.com/plainly-videos/after-effects-plugin/releases/tag/${data?.tag_name}`}
+              text="what's new"
+            />{' '}
+            and{' '}
+            <ExternalLink
+              to="https://exchange.adobe.com/apps/cc/202811/plainly-videos"
+              text="upgrade"
+            />
+            .
+          </p>
+        </Banner>
 
-      <div className="flex-1 overflow-y-auto">{route}</div>
+        <div className="flex-1 overflow-y-auto">{route}</div>
+      </TooltipProvider>
     </div>
   );
 }

--- a/plainly-plugin/src/ui/App.tsx
+++ b/plainly-plugin/src/ui/App.tsx
@@ -40,7 +40,7 @@ export function App() {
         <Button
           secondary
           onClick={reloadExtension}
-          className="absolute top-3 right-3 cursor-pointer z-40"
+          className="absolute top-3 right-3 cursor-pointer z-50"
         >
           Reload extension
         </Button>

--- a/plainly-plugin/src/ui/components/common/Banner.tsx
+++ b/plainly-plugin/src/ui/components/common/Banner.tsx
@@ -16,7 +16,7 @@ export function Banner({
         show ? 'flex' : 'hidden',
         'h-6 bg-indigo-500 opacity-70 bg-opacity-60 justify-center items-center',
         sidebarOpen
-          ? 'ml-[3.75rem] xs:ml-36 mr-[3.75rem] w-[calc(100%-3.75rem)] xs:w-[calc(100%-9rem)]'
+          ? 'ml-[3.75rem] xs:ml-[var(--sidebar-width)] mr-[3.75rem] w-[calc(100%-3.75rem)] xs:w-[calc(100%-9rem)]'
           : 'ml-[3.75rem] w-[calc(100%-3.75rem)]',
       )}
     >

--- a/plainly-plugin/src/ui/components/common/Banner.tsx
+++ b/plainly-plugin/src/ui/components/common/Banner.tsx
@@ -16,7 +16,7 @@ export function Banner({
         show ? 'flex' : 'hidden',
         'h-6 bg-indigo-500 opacity-70 bg-opacity-60 justify-center items-center',
         sidebarOpen
-          ? 'ml-[3.75rem] xs:ml-[var(--sidebar-width)] mr-[3.75rem] w-[calc(100%-3.75rem)] xs:w-[calc(100%-9rem)]'
+          ? 'ml-[3.75rem] xs:ml-[var(--sidebar-width)] mr-[3.75rem] w-[calc(100%-3.75rem)] xs:w-[calc(100%-var(--sidebar-width))]'
           : 'ml-[3.75rem] w-[calc(100%-3.75rem)]',
       )}
     >

--- a/plainly-plugin/src/ui/components/common/ConfirmationDialog.tsx
+++ b/plainly-plugin/src/ui/components/common/ConfirmationDialog.tsx
@@ -35,16 +35,18 @@ export function ConfirmationDialog({
     <Dialog open={open} onClose={setOpen} className="relative">
       <DialogBackdrop
         transition
-        className="fixed inset-0 backdrop-blur-md transition-opacity data-[closed]:opacity-0 data-[enter]:duration-300 data-[leave]:duration-200 data-[enter]:ease-out data-[leave]:ease-in"
+        className="fixed inset-0 z-20 backdrop-blur-md transition-opacity data-[closed]:opacity-0 data-[enter]:duration-300 data-[leave]:duration-200 data-[enter]:ease-out data-[leave]:ease-in"
       />
 
-      <div className="fixed inset-0 z-10 w-screen overflow-y-auto">
+      <div className="fixed inset-0 z-30 w-screen overflow-y-auto">
         <div className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
           <DialogPanel
             transition
             className={classNames(
               'relative transform overflow-hidden rounded-lg bg-[rgb(29,29,30)] px-4 pb-4 pt-5 text-left shadow-xl transition-all data-[closed]:translate-y-4 data-[closed]:opacity-0 data-[enter]:duration-300 data-[leave]:duration-200 data-[enter]:ease-out data-[leave]:ease-in sm:my-8 sm:w-full sm:max-w-lg sm:p-6 data-[closed]:sm:translate-y-0 data-[closed]:sm:scale-95 border border-white/10',
-              sidebarOpen ? 'ml-[3.75rem] xs:ml-36' : 'ml-[3.75rem]',
+              sidebarOpen
+                ? 'ml-[3.75rem] xs:ml-[var(--sidebar-width)]'
+                : 'ml-[3.75rem]',
             )}
           >
             <div className="sm:flex sm:items-start">

--- a/plainly-plugin/src/ui/components/common/NotificationsOverlay.tsx
+++ b/plainly-plugin/src/ui/components/common/NotificationsOverlay.tsx
@@ -85,7 +85,7 @@ export function NotificationsOverlay() {
   return (
     <div
       aria-live="assertive"
-      className="flex flex-col fixed pointer-events-none inset-0 justify-end px-4 py-6 sm:justify-start sm:p-6 z-50"
+      className="flex flex-col fixed pointer-events-none inset-0 justify-end px-4 py-6 sm:justify-start sm:p-6 z-40"
     >
       {notifications.map((notification) => (
         <Notification

--- a/plainly-plugin/src/ui/components/common/Tooltip.tsx
+++ b/plainly-plugin/src/ui/components/common/Tooltip.tsx
@@ -1,81 +1,62 @@
-import classNames from 'classnames';
-import { useCallback, useState } from 'react';
-import { createPortal } from 'react-dom';
+import { Tooltip as TooltipPrimitive } from '@base-ui/react/tooltip';
+import { cn } from '@src/ui/lib/utils';
 
-export function Tooltip({
-  text,
-  children,
-  position = 'top',
-  disabled,
-  className,
-}: {
-  text: string;
-  children: React.ReactNode;
-  position?: 'top' | 'bottom' | 'left' | 'right';
-  disabled?: boolean;
-  className?: string;
-}) {
-  const [visible, setVisible] = useState(false);
-  const [coords, setCoords] = useState({ top: 0, left: 0 });
-
-  const showTooltip = useCallback(
-    (event: React.MouseEvent) => {
-      const rect = event.currentTarget.getBoundingClientRect();
-      let newCoords = { top: rect.top, left: rect.left };
-
-      if (position === 'top') {
-        newCoords = { top: rect.top - 8, left: rect.left + rect.width / 2 };
-      } else if (position === 'bottom') {
-        newCoords = { top: rect.bottom + 8, left: rect.left + rect.width / 2 };
-      } else if (position === 'left') {
-        newCoords = { top: rect.top + rect.height / 2, left: rect.left - 8 };
-      } else if (position === 'right') {
-        newCoords = { top: rect.top + rect.height / 2, left: rect.right + 8 };
-      }
-
-      setCoords(newCoords);
-      setVisible(true);
-    },
-    [position],
-  );
-
-  if (disabled) {
-    return <>{children}</>;
-  }
-
+function TooltipProvider({
+  delay = 0,
+  ...props
+}: TooltipPrimitive.Provider.Props) {
   return (
-    <>
-      <div
-        className="relative inline-block"
-        onMouseEnter={showTooltip}
-        onMouseLeave={() => setVisible(false)}
-      >
-        {children}
-      </div>
-      {visible &&
-        createPortal(
-          <div
-            className={classNames(
-              'fixed z-50 bg-[rgb(43,43,43)] text-white text-xs px-2 py-1 rounded shadow-lg whitespace-nowrap border border-white/10',
-              className,
-            )}
-            style={{
-              top: `${coords.top}px`,
-              left: `${coords.left}px`,
-              transform:
-                position === 'top'
-                  ? 'translate(-50%, -100%)'
-                  : position === 'bottom'
-                    ? 'translateX(-50%)'
-                    : position === 'left'
-                      ? 'translate(-100%, -50%)'
-                      : 'translateY(-50%)',
-            }}
-          >
-            {text}
-          </div>,
-          document.body,
-        )}
-    </>
+    <TooltipPrimitive.Provider
+      data-slot="tooltip-provider"
+      delay={delay}
+      {...props}
+    />
   );
 }
+
+function Tooltip({ ...props }: TooltipPrimitive.Root.Props) {
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />;
+}
+
+function TooltipTrigger({ ...props }: TooltipPrimitive.Trigger.Props) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
+}
+
+function TooltipContent({
+  className,
+  side = 'top',
+  sideOffset = 4,
+  align = 'center',
+  alignOffset = 0,
+  children,
+  ...props
+}: TooltipPrimitive.Popup.Props &
+  Pick<
+    TooltipPrimitive.Positioner.Props,
+    'align' | 'alignOffset' | 'side' | 'sideOffset'
+  >) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Positioner
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+        className="isolate z-50"
+      >
+        <TooltipPrimitive.Popup
+          data-slot="tooltip-content"
+          className={cn(
+            'z-50 inline-flex w-fit max-w-xs origin-(--transform-origin) items-center gap-1.5 rounded-md bg-secondary px-2 py-1 text-xs text-white has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 border border-white/10',
+            className,
+          )}
+          {...props}
+        >
+          {children}
+        </TooltipPrimitive.Popup>
+      </TooltipPrimitive.Positioner>
+    </TooltipPrimitive.Portal>
+  );
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/plainly-plugin/src/ui/components/form/UploadForm.tsx
+++ b/plainly-plugin/src/ui/components/form/UploadForm.tsx
@@ -14,7 +14,14 @@ import { LoaderCircleIcon } from 'lucide-react';
 import { useCallback, useContext, useEffect, useState } from 'react';
 import { makeProjectZipTmpDir } from '../../../node';
 import { CanceledApiError } from '../../../node/errors';
-import { Alert, Button, InternalLink, Tooltip } from '../common';
+import {
+  Alert,
+  Button,
+  InternalLink,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '../common';
 import { GlobalContext } from '../context';
 import { Description, Label, PageHeading } from '../typography';
 
@@ -303,18 +310,20 @@ export function UploadForm() {
 
       <div className="flex gap-2 float-right">
         {loading && (
-          <Tooltip
-            text={isPacking ? 'Cannot cancel during packing' : ''}
-            disabled={!isPacking}
-          >
-            <Button
-              type="button"
-              secondary
-              onClick={() => (isUploading ? cancelUpload() : cancelEdit())}
-              disabled={isPacking}
-            >
-              Cancel
-            </Button>
+          <Tooltip disabled={!isPacking}>
+            <TooltipTrigger
+              render={
+                <Button
+                  type="button"
+                  secondary
+                  onClick={() => (isUploading ? cancelUpload() : cancelEdit())}
+                  disabled={isPacking}
+                >
+                  Cancel
+                </Button>
+              }
+            />
+            <TooltipContent>Cannot cancel during packing</TooltipContent>
           </Tooltip>
         )}
         <Button loading={loading} disabled={disabled || loading}>

--- a/plainly-plugin/src/ui/components/layout/MainWrapper.tsx
+++ b/plainly-plugin/src/ui/components/layout/MainWrapper.tsx
@@ -10,7 +10,7 @@ export function MainWrapper({ children }: { children: React.ReactNode }) {
     <main
       className={classNames(
         sidebarOpen
-          ? 'pl-[3.75rem] blur-md pointer-events-none xs:pl-36 xs:blur-none xs:pointer-events-auto'
+          ? 'pl-[3.75rem] blur-md pointer-events-none xs:pl-[var(--sidebar-width)] xs:blur-none xs:pointer-events-auto'
           : 'pl-[3.75rem]',
       )}
     >

--- a/plainly-plugin/src/ui/components/navigation/Sidebar.tsx
+++ b/plainly-plugin/src/ui/components/navigation/Sidebar.tsx
@@ -2,12 +2,27 @@ import { pages } from '@src/ui/routes';
 import { State, setGlobalState, useGlobalState } from '@src/ui/state/store';
 import classNames from 'classnames';
 import { ChevronLeftIcon, ChevronRightIcon } from 'lucide-react';
+import { useEffect, useRef } from 'react';
 import { PlainlyLogo } from '../logo';
 import { SidebarLinks, SidebarResources } from '.';
 
 export function Sidebar() {
   const [settings] = useGlobalState(State.SETTINGS);
   const sidebarOpen = settings.sidebarOpen;
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const observer = new ResizeObserver(() => {
+      document.documentElement.style.setProperty(
+        '--sidebar-width',
+        `${el.offsetWidth}px`,
+      );
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
 
   const handleSidebarOpen = () => {
     setGlobalState(State.SETTINGS, {
@@ -18,9 +33,10 @@ export function Sidebar() {
 
   return (
     <div
+      ref={ref}
       className={classNames(
-        'fixed left-0 inset-y-0 z-20 flex flex-col border-r border-r-white/10 bg-[rgb(29,29,30)]',
-        sidebarOpen ? 'w-[80%] xs:w-36' : 'w-[3.75rem]',
+        'fixed left-0 inset-y-0 z-30 flex flex-col border-r border-r-white/10 bg-[rgb(29,29,30)]',
+        sidebarOpen ? 'w-[80%] xs:w-max' : 'w-[3.75rem]',
       )}
     >
       {/* Sidebar component, swap this element with another sidebar if you like */}

--- a/plainly-plugin/src/ui/components/navigation/SidebarLinks.tsx
+++ b/plainly-plugin/src/ui/components/navigation/SidebarLinks.tsx
@@ -3,7 +3,7 @@ import type { Page, Separator } from '@src/ui/routes';
 import { isEmpty } from '@src/ui/utils';
 import classNames from 'classnames';
 import { useContext } from 'react';
-import { Tooltip } from '../common/Tooltip';
+import { Tooltip, TooltipContent, TooltipTrigger } from '../common/Tooltip';
 import { GlobalContext } from '../context';
 
 export function SidebarLinks({ links }: { links: (Page | Separator)[] }) {
@@ -19,27 +19,31 @@ export function SidebarLinks({ links }: { links: (Page | Separator)[] }) {
           {links.map((link) =>
             link.type === 'page' ? (
               <li key={link.name} className="w-full h-[25px]">
-                <Tooltip
-                  text={link.name}
-                  position="right"
-                  disabled={sidebarOpen}
-                >
-                  <button
-                    type="button"
-                    onClick={() => navigate(link.to)}
-                    className={classNames(
-                      link.to === currentPage
-                        ? 'bg-[rgb(43,43,43)] text-white'
-                        : 'text-gray-400 hover:bg-[rgb(43,43,43)] hover:text-white',
-                      'group flex gap-x-2 rounded-md px-2 py-1 text-xs font-medium relative items-center w-full h-[25px]',
-                    )}
-                  >
-                    <link.icon aria-hidden="true" className="size-4 shrink-0" />
-                    {valid === false && link.name === 'Validate' && (
-                      <span className="absolute top-0.5 right-1 inline-flex items-center justify-center h-2 w-2 bg-yellow-600 rounded-full" />
-                    )}
-                    {sidebarOpen && link.name}
-                  </button>
+                <Tooltip disabled={sidebarOpen}>
+                  <TooltipTrigger
+                    render={
+                      <button
+                        type="button"
+                        onClick={() => navigate(link.to)}
+                        className={classNames(
+                          link.to === currentPage
+                            ? 'bg-[rgb(43,43,43)] text-white'
+                            : 'text-gray-400 hover:bg-[rgb(43,43,43)] hover:text-white',
+                          'group flex gap-x-2 rounded-md px-2 py-1 text-xs font-medium relative items-center w-full h-[25px]',
+                        )}
+                      >
+                        <link.icon
+                          aria-hidden="true"
+                          className="size-4 shrink-0"
+                        />
+                        {valid === false && link.name === 'Validate' && (
+                          <span className="absolute top-0.5 right-1 inline-flex items-center justify-center h-2 w-2 bg-yellow-600 rounded-full" />
+                        )}
+                        {sidebarOpen && link.name}
+                      </button>
+                    }
+                  />
+                  <TooltipContent side="right">{link.name}</TooltipContent>
                 </Tooltip>
               </li>
             ) : (

--- a/plainly-plugin/src/ui/components/parametrization/FilterAndActions.tsx
+++ b/plainly-plugin/src/ui/components/parametrization/FilterAndActions.tsx
@@ -3,7 +3,7 @@ import type { LayerType, ScriptType } from '@src/ui/types/template';
 import classNames from 'classnames';
 import { ChevronDownIcon, CirclePileIcon, FunnelXIcon } from 'lucide-react';
 import { useState } from 'react';
-import { Tooltip } from '../common';
+import { Tooltip, TooltipContent, TooltipTrigger } from '../common';
 import { Label } from '../typography';
 import { ScriptsDialog } from './ScriptsDialog';
 
@@ -72,31 +72,32 @@ export function FilterAndActions({
                 className="origin-top-right rounded-md border border-white/5 bg-secondary p-1 focus:outline-none mt-1 z-10"
               >
                 <MenuItem>
-                  <button
-                    type="button"
+                  <span
                     className="group flex items-center gap-2 rounded-md px-3 py-1.5 text-xs text-gray-400 hover:bg-indigo-600 hover:text-white w-full"
                     onClick={clearFiltersAction}
                   >
                     <FunnelXIcon className="size-4 shrink-0 text-gray-400" />
                     Clear filters
-                  </button>
+                  </span>
                 </MenuItem>
-                <MenuItem>
-                  <Tooltip
-                    text="Select layers first"
-                    disabled={!bulkScriptDisabled}
-                  >
-                    <button
-                      type="button"
-                      className="group flex items-center gap-2 rounded-md px-3 py-1.5 text-xs text-gray-400 hover:bg-indigo-600 hover:text-white w-full disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-gray-400"
-                      onClick={() => setOpenScriptsDialog(true)}
-                      disabled={bulkScriptDisabled}
-                    >
-                      <CirclePileIcon className="size-4 shrink-0 text-gray-400" />
-                      Bulk script add
-                    </button>
-                  </Tooltip>
-                </MenuItem>
+                <Tooltip disabled={!bulkScriptDisabled}>
+                  <TooltipTrigger>
+                    <MenuItem>
+                      <span
+                        className={classNames(
+                          'group flex items-center gap-2 rounded-md px-3 py-1.5 text-xs text-gray-400 hover:bg-indigo-600 hover:text-white w-full',
+                          bulkScriptDisabled &&
+                            'pointer-events-none opacity-50',
+                        )}
+                        onClick={() => setOpenScriptsDialog(true)}
+                      >
+                        <CirclePileIcon className="size-4 shrink-0 text-gray-400" />
+                        Bulk script add
+                      </span>
+                    </MenuItem>
+                  </TooltipTrigger>
+                  <TooltipContent>Select layers first</TooltipContent>
+                </Tooltip>
               </MenuItems>
             </Menu>
           </div>

--- a/plainly-plugin/src/ui/components/parametrization/ParametrizedLayers.tsx
+++ b/plainly-plugin/src/ui/components/parametrization/ParametrizedLayers.tsx
@@ -35,7 +35,7 @@ import {
 } from 'lucide-react';
 import type React from 'react';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
-import { Tooltip } from '../common/Tooltip';
+import { Tooltip, TooltipContent, TooltipTrigger } from '../common/Tooltip';
 import { Label } from '../typography';
 import { ScriptBadge } from './ScriptBadge';
 import { ScriptsDialog } from './ScriptsDialog';
@@ -112,8 +112,11 @@ function SortableScriptItem({
       {isKnown ? (
         badge
       ) : (
-        <Tooltip text="Not supported yet, edit via web interface">
-          {badge}
+        <Tooltip>
+          <TooltipTrigger>{badge}</TooltipTrigger>
+          <TooltipContent>
+            Not supported yet, edit via web interface
+          </TooltipContent>
         </Tooltip>
       )}
     </div>
@@ -273,8 +276,11 @@ export function ParametrizedLayers({
             <Label label="Parameter" className="py-1 px-3" />
             <div className="py-1 px-3 flex items-center gap-1">
               <Label label="Scripts" />
-              <Tooltip text="Script order is important">
-                <InfoIcon className="size-4 text-gray-400" />
+              <Tooltip>
+                <TooltipTrigger>
+                  <InfoIcon className="size-4 text-gray-400" />
+                </TooltipTrigger>
+                <TooltipContent>Script order is important</TooltipContent>
               </Tooltip>
             </div>
           </li>

--- a/plainly-plugin/src/ui/components/parametrization/ScriptBadge.tsx
+++ b/plainly-plugin/src/ui/components/parametrization/ScriptBadge.tsx
@@ -42,8 +42,7 @@ export function ScriptBadge({
       <span className="tabular-nums">{index + 1}.</span>
       <span>{label}</span>
       {onRemove && (
-        <button
-          type="button"
+        <span
           className="absolute -top-1 -right-1 size-3.5 flex items-center justify-center rounded-full bg-gray-600 hover:bg-gray-500 cursor-pointer opacity-0 scale-50 group-hover:opacity-100 group-hover:scale-100 transition-all duration-150"
           onClick={(e) => {
             e.stopPropagation();
@@ -51,7 +50,7 @@ export function ScriptBadge({
           }}
         >
           <XIcon className="size-2.5" />
-        </button>
+        </span>
       )}
     </span>
   );

--- a/plainly-plugin/src/ui/components/parametrization/ScriptDialogShell.tsx
+++ b/plainly-plugin/src/ui/components/parametrization/ScriptDialogShell.tsx
@@ -34,14 +34,16 @@ export function ScriptDialogShell({
 
   return (
     <Dialog open={open} onClose={setOpen} className="relative">
-      <DialogBackdrop className="fixed inset-0 backdrop-blur-md" />
+      <DialogBackdrop className="fixed inset-0 z-20 backdrop-blur-md" />
 
-      <div className="fixed inset-0 z-10 w-screen overflow-y-auto">
+      <div className="fixed inset-0 z-30 w-screen overflow-y-auto">
         <div className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
           <DialogPanel
             className={classNames(
               'overflow-hidden rounded-lg bg-[rgb(29,29,30)] px-4 pb-4 pt-5 text-left sm:my-8 sm:w-full sm:max-w-lg sm:p-6 border border-white/10',
-              sidebarOpen ? 'ml-[3.75rem] xs:ml-36' : 'ml-[3.75rem]',
+              sidebarOpen
+                ? 'ml-[3.75rem] xs:ml-[var(--sidebar-width)]'
+                : 'ml-[3.75rem]',
             )}
           >
             <div className="flex flex-col gap-4">

--- a/plainly-plugin/src/ui/components/parametrization/ScriptsDialog.tsx
+++ b/plainly-plugin/src/ui/components/parametrization/ScriptsDialog.tsx
@@ -42,14 +42,16 @@ export function ScriptsDialog({
 
   return (
     <Dialog open={open} onClose={setOpen} className="relative">
-      <DialogBackdrop className="fixed inset-0 backdrop-blur-md" />
+      <DialogBackdrop className="fixed inset-0 z-20 backdrop-blur-md" />
 
-      <div className="fixed inset-0 z-10 w-screen overflow-y-auto">
+      <div className="fixed inset-0 z-30 w-screen overflow-y-auto">
         <div className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
           <DialogPanel
             className={classNames(
               'overflow-hidden rounded-lg bg-[rgb(29,29,30)] px-4 pb-4 pt-5 text-left sm:my-8 sm:w-full sm:max-w-lg sm:p-6 border border-white/10',
-              sidebarOpen ? 'ml-[3.75rem] xs:ml-36' : 'ml-[3.75rem]',
+              sidebarOpen
+                ? 'ml-[3.75rem] xs:ml-[var(--sidebar-width)]'
+                : 'ml-[3.75rem]',
             )}
           >
             <DialogTitle

--- a/plainly-plugin/src/ui/components/parametrization/ShiftScriptDialog.tsx
+++ b/plainly-plugin/src/ui/components/parametrization/ShiftScriptDialog.tsx
@@ -132,7 +132,7 @@ export function ShiftScriptDialog({
             anchor="bottom"
             transition
             className={classNames(
-              'min-w-[--input-width] rounded-md border border-white/5 bg-secondary p-1 mt-1 empty:invisible z-50',
+              'min-w-[--input-width] rounded-md border border-white/5 bg-secondary p-1 mt-1 empty:invisible z-10',
               'transition duration-100 ease-in',
             )}
           >
@@ -188,7 +188,7 @@ export function ShiftScriptDialog({
             anchor="bottom"
             transition
             className={classNames(
-              'min-w-[--input-width] rounded-md border border-white/5 bg-secondary p-1 mt-1 empty:invisible z-50',
+              'min-w-[--input-width] rounded-md border border-white/5 bg-secondary p-1 mt-1 empty:invisible z-10',
               'transition duration-100 ease-in',
             )}
           >

--- a/plainly-plugin/src/ui/components/parametrization/ShiftScriptDialog.tsx
+++ b/plainly-plugin/src/ui/components/parametrization/ShiftScriptDialog.tsx
@@ -132,7 +132,7 @@ export function ShiftScriptDialog({
             anchor="bottom"
             transition
             className={classNames(
-              'min-w-[--input-width] rounded-md border border-white/5 bg-secondary p-1 mt-1 empty:invisible z-10',
+              'min-w-[--input-width] rounded-md border border-white/5 bg-secondary p-1 mt-1 empty:invisible z-40',
               'transition duration-100 ease-in',
             )}
           >
@@ -188,7 +188,7 @@ export function ShiftScriptDialog({
             anchor="bottom"
             transition
             className={classNames(
-              'min-w-[--input-width] rounded-md border border-white/5 bg-secondary p-1 mt-1 empty:invisible z-10',
+              'min-w-[--input-width] rounded-md border border-white/5 bg-secondary p-1 mt-1 empty:invisible z-40',
               'transition duration-100 ease-in',
             )}
           >

--- a/plainly-plugin/src/ui/components/projects/LinkedProject.tsx
+++ b/plainly-plugin/src/ui/components/projects/LinkedProject.tsx
@@ -16,7 +16,12 @@ import {
   XCircleIcon,
 } from 'lucide-react';
 import { useCallback, useContext, useState } from 'react';
-import { ConfirmationDialog, Tooltip } from '../common';
+import {
+  ConfirmationDialog,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '../common';
 import { Label } from '../typography';
 import { ProjectAction } from '.';
 
@@ -92,21 +97,33 @@ export function LinkedProject({
               className="font-semibold whitespace-nowrap truncate"
             />
             <div className="flex items-center gap-2">
-              <Tooltip text="Unlink project">
-                <ProjectAction icon={LinkIcon} action={unlink} linked />
+              <Tooltip>
+                <TooltipTrigger>
+                  <ProjectAction icon={LinkIcon} action={unlink} linked />
+                </TooltipTrigger>
+                <TooltipContent>Unlink project</TooltipContent>
               </Tooltip>
-              <Tooltip text="Renders">
-                <ProjectAction icon={VideoIcon} action={openRenders} linked />
+              <Tooltip>
+                <TooltipTrigger>
+                  <ProjectAction icon={VideoIcon} action={openRenders} linked />
+                </TooltipTrigger>
+                <TooltipContent>Renders</TooltipContent>
               </Tooltip>
-              <Tooltip text="Open in web">
-                <ProjectAction icon={ExternalLinkIcon} action={open} linked />
+              <Tooltip>
+                <TooltipTrigger>
+                  <ProjectAction icon={ExternalLinkIcon} action={open} linked />
+                </TooltipTrigger>
+                <TooltipContent>Open in web</TooltipContent>
               </Tooltip>
-              <Tooltip text="Parametrization">
-                <ProjectAction
-                  icon={LayersPlusIcon}
-                  action={() => navigate(Routes.PARAMETRIZATION)}
-                  linked
-                />
+              <Tooltip>
+                <TooltipTrigger>
+                  <ProjectAction
+                    icon={LayersPlusIcon}
+                    action={() => navigate(Routes.PARAMETRIZATION)}
+                    linked
+                  />
+                </TooltipTrigger>
+                <TooltipContent>Parametrization</TooltipContent>
               </Tooltip>
             </div>
           </div>
@@ -116,8 +133,11 @@ export function LinkedProject({
                 {getStatus(analysisDone, analysisFailed)}
               </div>
               <div className="flex items-center gap-1">
-                <Tooltip text="Sync status">
-                  <FolderSync className="size-3" />
+                <Tooltip>
+                  <TooltipTrigger>
+                    <FolderSync className="size-3" />
+                  </TooltipTrigger>
+                  <TooltipContent>Sync status</TooltipContent>
                 </Tooltip>
                 <p>Local v{plainlyProject?.revisionCount || 0}</p>
                 <svg

--- a/plainly-plugin/src/ui/components/projects/ProjectAction.tsx
+++ b/plainly-plugin/src/ui/components/projects/ProjectAction.tsx
@@ -11,17 +11,16 @@ export function ProjectAction({
   linked?: boolean;
 }) {
   return (
-    <button
+    <span
       className={classNames(
         'size-5 flex items-center justify-center cursor-pointer disabled:cursor-not-allowed group rounded-sm',
         linked
           ? 'bg-primary hover:bg-secondary hover:text-gray-400'
           : 'bg-secondary hover:bg-primary hover:text-gray-400',
       )}
-      type="button"
       onClick={action}
     >
       <Icon className="size-3" />
-    </button>
+    </span>
   );
 }

--- a/plainly-plugin/src/ui/components/projects/ProjectsListItem.tsx
+++ b/plainly-plugin/src/ui/components/projects/ProjectsListItem.tsx
@@ -4,7 +4,12 @@ import { format } from 'date-fns';
 import { ExternalLinkIcon, LinkIcon, VideoIcon } from 'lucide-react';
 import type { ProjectData } from 'plainly-types';
 import { useCallback, useState } from 'react';
-import { ConfirmationDialog, Tooltip } from '../common';
+import {
+  ConfirmationDialog,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '../common';
 import { Label } from '../typography';
 import { ProjectAction } from '.';
 
@@ -74,15 +79,20 @@ export function ProjectsListItem({
       <li className="p-2 text-xs min-w-fit w-full">
         <div className="flex items-center justify-between w-full">
           <div className="flex items-center">
-            <Tooltip text={statusText}>
-              <div
-                className={classNames(
-                  statuses[status],
-                  'flex-none rounded-full p-1',
-                )}
-              >
-                <div className="size-1 rounded-full bg-current" />
-              </div>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <div
+                    className={classNames(
+                      statuses[status],
+                      'flex-none rounded-full p-1',
+                    )}
+                  >
+                    <div className="size-1 rounded-full bg-current" />
+                  </div>
+                }
+              />
+              <TooltipContent>{statusText}</TooltipContent>
             </Tooltip>
             <Label
               label={project.name}
@@ -93,14 +103,23 @@ export function ProjectsListItem({
             </p>
           </div>
           <div className="flex items-center gap-2 ml-2">
-            <Tooltip text="Link project">
-              <ProjectAction icon={LinkIcon} action={link} />
+            <Tooltip>
+              <TooltipTrigger>
+                <ProjectAction icon={LinkIcon} action={link} />
+              </TooltipTrigger>
+              <TooltipContent>Link project</TooltipContent>
             </Tooltip>
-            <Tooltip text="Renders">
-              <ProjectAction icon={VideoIcon} action={openRenders} />
+            <Tooltip>
+              <TooltipTrigger>
+                <ProjectAction icon={VideoIcon} action={openRenders} />
+              </TooltipTrigger>
+              <TooltipContent>Renders</TooltipContent>
             </Tooltip>
-            <Tooltip text="Open in web">
-              <ProjectAction icon={ExternalLinkIcon} action={open} />
+            <Tooltip>
+              <TooltipTrigger>
+                <ProjectAction icon={ExternalLinkIcon} action={open} />
+              </TooltipTrigger>
+              <TooltipContent>Open in web</TooltipContent>
             </Tooltip>
           </div>
         </div>

--- a/plainly-plugin/src/ui/components/settings/MissingApiKey.tsx
+++ b/plainly-plugin/src/ui/components/settings/MissingApiKey.tsx
@@ -10,8 +10,10 @@ export function MissingApiKey() {
   return (
     <div
       className={classNames(
-        'absolute inset-0 w-full h-screen flex items-center justify-center bg-[rgb(29,29,30)] z-10',
-        sidebarOpen ? 'pl-[3.75rem] xs:pl-36' : 'pl-[3.75rem]',
+        'absolute inset-0 w-full h-screen flex items-center justify-center bg-[rgb(29,29,30)] z-20',
+        sidebarOpen
+          ? 'pl-[3.75rem] xs:pl-[var(--sidebar-width)]'
+          : 'pl-[3.75rem]',
       )}
     >
       <div className="p-6 sm:p-14 lg:p-20 flex flex-col items-center justify-center">

--- a/plainly-plugin/src/ui/components/settings/PinOverlay.tsx
+++ b/plainly-plugin/src/ui/components/settings/PinOverlay.tsx
@@ -32,8 +32,10 @@ export function PinOverlay({
   return (
     <form
       className={classNames(
-        'absolute inset-0 w-full h-screen flex items-center justify-center bg-[rgb(29,29,30)] z-10',
-        sidebarOpen ? 'pl-[3.75rem] xs:pl-36' : 'pl-[3.75rem]',
+        'absolute inset-0 w-full h-screen flex items-center justify-center bg-[rgb(29,29,30)] z-20',
+        sidebarOpen
+          ? 'pl-[3.75rem] xs:pl-[var(--sidebar-width)]'
+          : 'pl-[3.75rem]',
       )}
       onSubmit={handleSubmit}
     >

--- a/plainly-plugin/src/ui/components/validate/Issue.tsx
+++ b/plainly-plugin/src/ui/components/validate/Issue.tsx
@@ -10,7 +10,7 @@ import {
 } from 'lucide-react';
 import type { AnyProjectIssue } from 'plainly-types';
 import { useCallback } from 'react';
-import { Tooltip } from '../common';
+import { Tooltip, TooltipContent, TooltipTrigger } from '../common';
 import { ProjectIssueType } from '.';
 
 export function Issue({
@@ -42,46 +42,60 @@ export function Issue({
       >
         <div className="flex items-center gap-2">
           <p>{label}</p>
-          <Tooltip
-            text={description}
-            className="max-w-40 whitespace-break-spaces"
-          >
-            <div className="flex items-center justify-center cursor-help size-4 group">
-              <CircleQuestionMark className="size-4 text-gray-400 group-hover:text-white duration-200" />
-            </div>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <div className="flex items-center justify-center cursor-help size-4 group">
+                  <CircleQuestionMark className="size-4 text-gray-400 group-hover:text-white duration-200" />
+                </div>
+              }
+            />
+            <TooltipContent>{description}</TooltipContent>
           </Tooltip>
-          <Tooltip text="Read more">
-            <div className="flex items-center justify-center cursor-pointer size-4 group">
-              <button
-                type="button"
-                onClick={() => handleLinkClick(externalLink)}
-                className="flex items-center justify-center"
-              >
-                <ExternalLinkIcon className="size-4 text-gray-400 group-hover:text-white duration-200" />
-              </button>
-            </div>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <div className="flex items-center justify-center cursor-pointer size-4 group">
+                  <button
+                    type="button"
+                    onClick={() => handleLinkClick(externalLink)}
+                    className="flex items-center justify-center"
+                  >
+                    <ExternalLinkIcon className="size-4 text-gray-400 group-hover:text-white duration-200" />
+                  </button>
+                </div>
+              }
+            />
+            <TooltipContent>Read more</TooltipContent>
           </Tooltip>
           {warning && (
-            <Tooltip
-              text={warning}
-              className="whitespace-break-spaces max-w-sm"
-            >
-              <div className="flex items-center justify-center cursor-help size-4 group">
-                <TriangleAlertIcon className="size-4 text-gray-400 group-hover:text-white duration-200" />
-              </div>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <div className="flex items-center justify-center cursor-help size-4 group">
+                    <TriangleAlertIcon className="size-4 text-gray-400 group-hover:text-white duration-200" />
+                  </div>
+                }
+              />
+              <TooltipContent>{warning}</TooltipContent>
             </Tooltip>
           )}
-          <Tooltip text="Fix this issue" disabled={Boolean(warning)}>
-            <div className="flex items-center justify-center cursor-pointer size-4 group">
-              <button
-                type="button"
-                onClick={onFixClick}
-                className="flex items-center justify-center disabled:cursor-not-allowed disabled:opacity-50"
-                disabled={Boolean(warning)}
-              >
-                <WrenchIcon className="size-4 text-gray-400 group-hover:text-white duration-200" />
-              </button>
-            </div>
+          <Tooltip disabled={Boolean(warning)}>
+            <TooltipTrigger
+              render={
+                <div className="flex items-center justify-center cursor-pointer size-4 group">
+                  <button
+                    type="button"
+                    onClick={onFixClick}
+                    className="flex items-center justify-center disabled:cursor-not-allowed disabled:opacity-50"
+                    disabled={Boolean(warning)}
+                  >
+                    <WrenchIcon className="size-4 text-gray-400 group-hover:text-white duration-200" />
+                  </button>
+                </div>
+              }
+            />
+            <TooltipContent>Fix this issue</TooltipContent>
           </Tooltip>
         </div>
         <div className="flex items-center gap-2">

--- a/plainly-plugin/src/ui/lib/utils.ts
+++ b/plainly-plugin/src/ui/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1455,6 +1455,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.28.6":
+  version: 7.29.2
+  resolution: "@babel/runtime@npm:7.29.2"
+  checksum: d5548d1165de8995f8afc93a5694b8625409be16cd1f2250ac13e331335858ddac3cb9fd278e6c43956a130101a2203f09417938a1a96f9fb70f02b4b4172e1d
+  languageName: node
+  linkType: hard
+
 "@babel/template@npm:^7.27.2":
   version: 7.27.2
   resolution: "@babel/template@npm:7.27.2"
@@ -1524,6 +1531,46 @@ __metadata:
     "@babel/helper-string-parser": ^7.27.1
     "@babel/helper-validator-identifier": ^7.28.5
   checksum: 5bc266af9e55ff92f9ddf33d83a42c9de1a87f9579d0ed62ef94a741a081692dd410a4fbbab18d514b83e135083ff05bc0e37003834801c9514b9d8ad748070d
+  languageName: node
+  linkType: hard
+
+"@base-ui/react@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "@base-ui/react@npm:1.3.0"
+  dependencies:
+    "@babel/runtime": ^7.28.6
+    "@base-ui/utils": 0.2.6
+    "@floating-ui/react-dom": ^2.1.8
+    "@floating-ui/utils": ^0.2.11
+    tabbable: ^6.4.0
+    use-sync-external-store: ^1.6.0
+  peerDependencies:
+    "@types/react": ^17 || ^18 || ^19
+    react: ^17 || ^18 || ^19
+    react-dom: ^17 || ^18 || ^19
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: c9f99003d0b42bab663cb12b5d1349ddf161816968d4a0f51b9d7aa64c9ee99619dfb328e14a0cfb44458cf931fc23b4e6c210a2cee2e79e666939c5ad6be0a2
+  languageName: node
+  linkType: hard
+
+"@base-ui/utils@npm:0.2.6":
+  version: 0.2.6
+  resolution: "@base-ui/utils@npm:0.2.6"
+  dependencies:
+    "@babel/runtime": ^7.28.6
+    "@floating-ui/utils": ^0.2.11
+    reselect: ^5.1.1
+    use-sync-external-store: ^1.6.0
+  peerDependencies:
+    "@types/react": ^17 || ^18 || ^19
+    react: ^17 || ^18 || ^19
+    react-dom: ^17 || ^18 || ^19
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 2d0cde7204d899f28931a466c74316f7b2aa1386f8267172cd98107a514ffdc98a7880ded519c7c5aecee5d766fd3cdcaef5110c05bf6bf1c090e4f7d22387a5
   languageName: node
   linkType: hard
 
@@ -1725,6 +1772,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@floating-ui/core@npm:^1.7.5":
+  version: 1.7.5
+  resolution: "@floating-ui/core@npm:1.7.5"
+  dependencies:
+    "@floating-ui/utils": ^0.2.11
+  checksum: 9dda28bb1d301305ba407ad61fc1acf0f498819a6976e0b9c0a91069d92fb4b4bc8d6cffd1c68c4c281cffd0f7d267cbc2e56ea622f91c342aaa060d5b73d5db
+  languageName: node
+  linkType: hard
+
 "@floating-ui/dom@npm:^1.7.4":
   version: 1.7.4
   resolution: "@floating-ui/dom@npm:1.7.4"
@@ -1732,6 +1788,16 @@ __metadata:
     "@floating-ui/core": ^1.7.3
     "@floating-ui/utils": ^0.2.10
   checksum: 806923e6f5b09e024c366070f2115a4db6e8ad28462bac29cd075170a6f7d900497da3ee542439bd0770b8e2fff12b636cc30873d1c82e9ec4a487870b080643
+  languageName: node
+  linkType: hard
+
+"@floating-ui/dom@npm:^1.7.6":
+  version: 1.7.6
+  resolution: "@floating-ui/dom@npm:1.7.6"
+  dependencies:
+    "@floating-ui/core": ^1.7.5
+    "@floating-ui/utils": ^0.2.11
+  checksum: 0c1ba371a2e5b8cdbd6a88daafd8bb22cc415a5b50dbf23d829842c1551efe8e74fed5d34c89644fa8ee5dcf9b0470f9b2e9a3f82f91622abe6e1284b272d1c1
   languageName: node
   linkType: hard
 
@@ -1744,6 +1810,18 @@ __metadata:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
   checksum: 24ff266806cd4cba6ad066f0eda7b99583f68af877f41df0b2a8d10a392692e3a1c1d666ebb75571a060818ede940bae59d833aa517ed538f7dba9dddd9991ae
+  languageName: node
+  linkType: hard
+
+"@floating-ui/react-dom@npm:^2.1.8":
+  version: 2.1.8
+  resolution: "@floating-ui/react-dom@npm:2.1.8"
+  dependencies:
+    "@floating-ui/dom": ^1.7.6
+  peerDependencies:
+    react: ">=16.8.0"
+    react-dom: ">=16.8.0"
+  checksum: f81777f92bfbdc3bdb852f3c15d2609ffcd207e15db7cd2b58680ea9bd0574ba37a472475dfb71dbfcbfbdef40792ab8120f327df2050d52193bafff8db9aa71
   languageName: node
   linkType: hard
 
@@ -1765,6 +1843,13 @@ __metadata:
   version: 0.2.10
   resolution: "@floating-ui/utils@npm:0.2.10"
   checksum: ffc4c24a46a665cfd0337e9aaf7de8415b572f8a0f323af39175e4b575582aed13d172e7f049eedeece9eaf022bad019c140a2d192580451984ae529bdf1285c
+  languageName: node
+  linkType: hard
+
+"@floating-ui/utils@npm:^0.2.11":
+  version: 0.2.11
+  resolution: "@floating-ui/utils@npm:0.2.11"
+  checksum: e98a2da3e36bd476460b0b85c3ba37c254516790d8c5eafa79ecf67bae7f2230c46d5fabce196aaf08bcd31586828e2df718cd2ccd1d333f18120f8adef66828
   languageName: node
   linkType: hard
 
@@ -3717,7 +3802,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"clsx@npm:^2.0.0":
+"clsx@npm:^2.0.0, clsx@npm:^2.1.1":
   version: 2.1.1
   resolution: "clsx@npm:2.1.1"
   checksum: acd3e1ab9d8a433ecb3cc2f6a05ab95fe50b4a3cfc5ba47abb6cbf3754585fcb87b84e90c822a1f256c4198e3b41c7f6c391577ffc8678ad587fc0976b24fd57
@@ -6583,6 +6668,7 @@ __metadata:
     "@babel/preset-env": ^7.28.6
     "@babel/preset-react": ^7.26.3
     "@babel/preset-typescript": ^7.28.5
+    "@base-ui/react": ^1.3.0
     "@dnd-kit/core": ^6.3.1
     "@dnd-kit/sortable": ^8.0.0
     "@headlessui/react": ^2.2.0
@@ -6604,6 +6690,7 @@ __metadata:
     babel-jest: ^30.2.0
     babel-loader: ^9.2.1
     classnames: ^2.5.1
+    clsx: ^2.1.1
     cross-env: ^10.0.0
     css-loader: ^7.1.2
     date-fns: ^4.1.0
@@ -6623,6 +6710,7 @@ __metadata:
     rimraf: ^6.1.3
     semver: ^7.7.4
     style-loader: ^4.0.0
+    tailwind-merge: ^3.5.0
     tailwindcss: ^3.4.15
     ts-jest: ^29.4.6
     ts-loader: ^9.5.1
@@ -7047,6 +7135,13 @@ __metadata:
   version: 2.0.2
   resolution: "require-from-string@npm:2.0.2"
   checksum: a03ef6895445f33a4015300c426699bc66b2b044ba7b670aa238610381b56d3f07c686251740d575e22f4c87531ba662d06937508f0f3c0f1ddc04db3130560b
+  languageName: node
+  linkType: hard
+
+"reselect@npm:^5.1.1":
+  version: 5.1.1
+  resolution: "reselect@npm:5.1.1"
+  checksum: 5d32d48be29071ddda21a775945c2210cf4ca3fccde1c4a0e1582ac3bf99c431c6c2330ef7ca34eae4c06feea617e7cb2c275c4b33ccf9a930836dfc98b49b13
   languageName: node
   linkType: hard
 
@@ -7513,6 +7608,20 @@ __metadata:
   version: 6.3.0
   resolution: "tabbable@npm:6.3.0"
   checksum: 5ffeb2db569db7f3fe11b766f599bc0b67100697034e5c6264995555e8dead029c2e51d6b1e5ea65781e9077bf05ca40d3313c1c47351124a7e68727bc0f3968
+  languageName: node
+  linkType: hard
+
+"tabbable@npm:^6.4.0":
+  version: 6.4.0
+  resolution: "tabbable@npm:6.4.0"
+  checksum: 7084cba269ebbc7dcdeed5aca7f90c0a0fb59a295dd1e83703ab89cca5e6c53b78d02020e3d1065481984cd64bba7dd1ea3c0a48e92fdba83d586e6e86d62a74
+  languageName: node
+  linkType: hard
+
+"tailwind-merge@npm:^3.5.0":
+  version: 3.5.0
+  resolution: "tailwind-merge@npm:3.5.0"
+  checksum: 34d1ba25a9e55fdc0885a14221650623472b70c969b8da0dd494753a311318469f203b21fc2278d9b679d41c04451b5e2c725d14d0f510ca07feae903c6479d3
   languageName: node
   linkType: hard
 
@@ -8072,7 +8181,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"use-sync-external-store@npm:^1.5.0":
+"use-sync-external-store@npm:^1.5.0, use-sync-external-store@npm:^1.6.0":
   version: 1.6.0
   resolution: "use-sync-external-store@npm:1.6.0"
   peerDependencies:


### PR DESCRIPTION
## Summary

There are two issues with #137 . 
1. First is that Sidebar is now getting small, because new link is named `Parametrization`, and we had fixed width of `36. This is solved by getting real time data of sidebar width.
2. Second is that some z values are wrong, this was seen in new `sticky` element in a Parametrized layers list, it is visible while dialog is visible also. So I've adjusted some `z`s in this order:
    - max z -> tooltip and reload button
    - then notification overlay
    - then dialogs and sidebar
    - then pin + backdrop blurs
    - then these stickies and menus / dropdowns we have
3. Tooltip refactor -> use BaseUI tooltip, shadcn guide for manual implementation

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / internal improvement
- [ ] Dependency update
- [ ] Docs / tooling

## Related issue

#137 

## Testing

<!-- How was this tested? Check all that apply. -->

- [x] Tested manually in After Effects
- [ ] Unit tests added / updated
- [ ] Existing tests pass (`yarn test`)

**After Effects version tested:**
**OS tested on:**

## Screenshots

<!-- If this changes the UI, include before/after screenshots. -->

## Checklist

- [x] `yarn biome` passes (or `yarn biome:fix` was run)
- [x] `yarn build` completes without errors
- [x] No new TypeScript errors
