### PR TITLE
fix: improve permission write error

### DIFF
--- a/plainly-plugin/src/node/errors.ts
+++ b/plainly-plugin/src/node/errors.ts
@@ -4,6 +4,7 @@ export class FolderPermissionError extends Error {
     super(
       `No write permission for folder: ${folderPath}. Please ensure you have write access and try again.`,
     );
+    this.name = 'FolderPermissionError';
     this.folderPath = folderPath;
     Object.setPrototypeOf(this, FolderPermissionError.prototype);
   }

--- a/plainly-plugin/src/node/errors.ts
+++ b/plainly-plugin/src/node/errors.ts
@@ -1,3 +1,14 @@
+export class FolderPermissionError extends Error {
+  folderPath: string;
+  constructor(folderPath: string) {
+    super(
+      `No write permission for folder: ${folderPath}. Please ensure you have write access and try again.`,
+    );
+    this.folderPath = folderPath;
+    Object.setPrototypeOf(this, FolderPermissionError.prototype);
+  }
+}
+
 export class CollectFootageError extends Error {
   errorPaths: string[];
   constructor(errorPaths: string[]) {

--- a/plainly-plugin/src/node/utils.ts
+++ b/plainly-plugin/src/node/utils.ts
@@ -11,9 +11,11 @@ import { isWindows } from './constants';
 import { FolderPermissionError } from './errors';
 
 function isPermissionError(error: unknown): boolean {
+  if (error === null || typeof error !== 'object') return false;
   const code = (error as NodeJS.ErrnoException).code;
   return code === 'EPERM' || code === 'EACCES';
 }
+
 /**
  * Checks if a file or directory exists at the given path.
  * @param path - The path to check.
@@ -66,7 +68,7 @@ export async function renameIfExists(src: string, dest: string): Promise<void> {
     await fsPromises.rename(src, dest);
   } catch (error) {
     if (isPermissionError(error)) {
-      throw new FolderPermissionError(src);
+      throw new FolderPermissionError(path.dirname(src));
     }
     throw error;
   }

--- a/plainly-plugin/src/node/utils.ts
+++ b/plainly-plugin/src/node/utils.ts
@@ -8,6 +8,12 @@ const homeDirectory = os.homedir();
 
 import archiver from 'archiver';
 import { isWindows } from './constants';
+import { FolderPermissionError } from './errors';
+
+function isPermissionError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException).code;
+  return code === 'EPERM' || code === 'EACCES';
+}
 /**
  * Checks if a file or directory exists at the given path.
  * @param path - The path to check.
@@ -56,7 +62,14 @@ export async function renameIfExists(src: string, dest: string): Promise<void> {
     return;
   }
 
-  await fsPromises.rename(src, dest);
+  try {
+    await fsPromises.rename(src, dest);
+  } catch (error) {
+    if (isPermissionError(error)) {
+      throw new FolderPermissionError(src);
+    }
+    throw error;
+  }
 }
 
 /**
@@ -125,14 +138,28 @@ export const zipItems = async (
   items: { src: string; dest: string; isRequired: boolean }[],
 ): Promise<string> => {
   return new Promise((resolve, reject) => {
-    const output = fs.createWriteStream(outputZipPath);
+    let output: fs.WriteStream;
+    try {
+      output = fs.createWriteStream(outputZipPath);
+    } catch (error) {
+      if (isPermissionError(error)) {
+        reject(new FolderPermissionError(path.dirname(outputZipPath)));
+      } else {
+        reject(error);
+      }
+      return;
+    }
     const archive = archiver('zip', { zlib: { level: 1 } });
 
     output.on('close', () => resolve(outputZipPath));
 
     output.on('error', (err) => {
       archive.destroy();
-      reject(err);
+      if (isPermissionError(err)) {
+        reject(new FolderPermissionError(path.dirname(outputZipPath)));
+      } else {
+        reject(err);
+      }
     });
 
     archive.on('error', (err) => {

--- a/plainly-plugin/src/ui/components/common/NotificationsOverlay.tsx
+++ b/plainly-plugin/src/ui/components/common/NotificationsOverlay.tsx
@@ -10,6 +10,7 @@ function Notification({
   type,
   description,
   code,
+  action,
   onClose,
   isFirst,
   isLast,
@@ -18,6 +19,7 @@ function Notification({
   type: NotificationType;
   description?: string;
   code?: string;
+  action?: { label: string; onClick: () => void };
   onClose: () => void;
   isFirst?: boolean;
   isLast?: boolean;
@@ -34,7 +36,7 @@ function Notification({
             isLast && 'rounded-b-lg',
           )}
         >
-          <div className="p-4">
+          <div className="p-4 relative">
             <div className="flex items-start">
               <div className="shrink-0">
                 {type === 'success' && (
@@ -59,8 +61,17 @@ function Notification({
                   <p className="mt-1 text-sm text-gray-400">{description}</p>
                 )}
                 {code && <p className="mt-1 text-xs text-gray-500">{code}</p>}
+                {action && (
+                  <button
+                    type="button"
+                    onClick={action.onClick}
+                    className="mt-2 text-xs font-medium text-indigo-400 hover:text-indigo-300"
+                  >
+                    {action.label}
+                  </button>
+                )}
               </div>
-              <div className="ml-4 flex shrink-0">
+              <div className="absolute top-4 right-4">
                 <button
                   type="button"
                   onClick={onClose}
@@ -94,6 +105,7 @@ export function NotificationsOverlay() {
           type={notification.type}
           description={notification.description}
           code={notification.code}
+          action={notification.action}
           onClose={() => clearNotification(notification.id)}
           isFirst={notifications.indexOf(notification) === 0}
           isLast={

--- a/plainly-plugin/src/ui/components/common/NotificationsOverlay.tsx
+++ b/plainly-plugin/src/ui/components/common/NotificationsOverlay.tsx
@@ -1,6 +1,6 @@
 import { Transition } from '@headlessui/react';
 import { useNotifications } from '@src/ui/hooks';
-import type { NotificationType } from '@src/ui/types';
+import type { NotificationAction, NotificationType } from '@src/ui/types';
 import classNames from 'classnames';
 import { CircleCheckBigIcon, InfoIcon, XIcon } from 'lucide-react';
 import { Button } from './Button';
@@ -19,7 +19,7 @@ function Notification({
   type: NotificationType;
   description?: string;
   code?: string;
-  action?: { label: string; onClick: () => void };
+  action?: NotificationAction;
   onClose: () => void;
   isFirst?: boolean;
   isLast?: boolean;
@@ -55,7 +55,7 @@ function Notification({
                   />
                 )}
               </div>
-              <div className="ml-3 w-0 flex-1 pt-0.5">
+              <div className="ml-3 w-0 flex-1 pt-0.5 pr-8">
                 <p className="text-sm font-medium text-white">{title}</p>
                 {description && (
                   <p className="mt-1 text-sm text-gray-400">{description}</p>

--- a/plainly-plugin/src/ui/components/form/ExportForm.tsx
+++ b/plainly-plugin/src/ui/components/form/ExportForm.tsx
@@ -1,6 +1,8 @@
+import { FolderPermissionError } from '@src/node/errors';
 import { useNotifications } from '@src/ui/hooks';
 import classNames from 'classnames';
 import { FolderIcon } from 'lucide-react';
+import path from 'path';
 import { useCallback, useState } from 'react';
 import { makeProjectZip, selectFolder } from '../../../node/index';
 import { openFolder } from '../../../node/utils';
@@ -25,7 +27,14 @@ export function ExportForm() {
 
         if (openLocation) openFolder(targetPath);
       } catch (error) {
-        notifyError('Failed to collect files', error);
+        const action =
+          error instanceof FolderPermissionError
+            ? {
+                label: 'Open folder',
+                onClick: () => openFolder(path.dirname(error.folderPath)),
+              }
+            : undefined;
+        notifyError('Failed to collect files', error, action);
         setLoading(false);
       }
     }

--- a/plainly-plugin/src/ui/components/form/ExportForm.tsx
+++ b/plainly-plugin/src/ui/components/form/ExportForm.tsx
@@ -2,7 +2,6 @@ import { FolderPermissionError } from '@src/node/errors';
 import { useNotifications } from '@src/ui/hooks';
 import classNames from 'classnames';
 import { FolderIcon } from 'lucide-react';
-import path from 'path';
 import { useCallback, useState } from 'react';
 import { makeProjectZip, selectFolder } from '../../../node/index';
 import { openFolder } from '../../../node/utils';
@@ -31,7 +30,7 @@ export function ExportForm() {
           error instanceof FolderPermissionError
             ? {
                 label: 'Open folder',
-                onClick: () => openFolder(path.dirname(error.folderPath)),
+                onClick: () => openFolder(error.folderPath),
               }
             : undefined;
         notifyError('Failed to collect files', error, action);

--- a/plainly-plugin/src/ui/components/form/UploadForm.tsx
+++ b/plainly-plugin/src/ui/components/form/UploadForm.tsx
@@ -13,7 +13,8 @@ import fs from 'fs';
 import { LoaderCircleIcon } from 'lucide-react';
 import { useCallback, useContext, useEffect, useState } from 'react';
 import { makeProjectZipTmpDir } from '../../../node';
-import { CanceledApiError } from '../../../node/errors';
+import { CanceledApiError, FolderPermissionError } from '../../../node/errors';
+import { openFolder } from '../../../node/utils';
 import { Alert, Button, InternalLink, Tooltip } from '../common';
 import { GlobalContext } from '../context';
 import { Description, Label, PageHeading } from '../typography';
@@ -154,7 +155,14 @@ export function UploadForm() {
         return;
       }
       setUploadProgress(0);
-      notifyError('Failed to upload project', error);
+      const action =
+        error instanceof FolderPermissionError
+          ? {
+              label: 'Open folder',
+              onClick: () => openFolder(error.folderPath),
+            }
+          : undefined;
+      notifyError('Failed to upload project', error, action);
     } finally {
       if (zipPathValue) {
         fs.rmSync(zipPathValue);

--- a/plainly-plugin/src/ui/hooks/useNotifications.ts
+++ b/plainly-plugin/src/ui/hooks/useNotifications.ts
@@ -2,7 +2,11 @@ import { getErrorDescription } from '@src/node/errors';
 import crypto from 'crypto';
 import { useCallback } from 'react';
 import { State, useGlobalState } from '../state/store';
-import { type Notification, NotificationType } from '../types';
+import {
+  type Notification,
+  type NotificationAction,
+  NotificationType,
+} from '../types';
 
 export const useNotifications = () => {
   const [notifications, setNotifications] = useGlobalState(State.NOTIFICATIONS);
@@ -13,12 +17,14 @@ export const useNotifications = () => {
       type: NotificationType,
       description?: string,
       code?: string,
+      action?: NotificationAction,
     ) => {
       const notification: Notification = {
         title,
         type,
         description,
         code,
+        action,
         id: crypto.randomUUID(),
       };
 
@@ -49,9 +55,9 @@ export const useNotifications = () => {
   );
 
   const notifyError = useCallback(
-    (title: string, details?: unknown) => {
+    (title: string, details?: unknown, action?: NotificationAction) => {
       const { description, code } = getErrorDescription(details) || {};
-      newNotification(title, NotificationType.ERROR, description, code);
+      newNotification(title, NotificationType.ERROR, description, code, action);
     },
     [newNotification],
   );

--- a/plainly-plugin/src/ui/types/index.ts
+++ b/plainly-plugin/src/ui/types/index.ts
@@ -19,12 +19,18 @@ export enum NotificationType {
   INFO = 'info',
 }
 
+export interface NotificationAction {
+  label: string;
+  onClick: () => void;
+}
+
 export interface Notification {
   id: string;
   title: string;
   type: NotificationType;
   description?: string;
   code?: string;
+  action?: NotificationAction;
 }
 
 export class Pin {


### PR DESCRIPTION
## Summary

When user doesn't have permission to edit folder (and we need to edit it also), he gets `EPERM` or `EACESS` error. This shows nice message, and also gives you a button to go to the desired folder.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / internal improvement
- [ ] Dependency update
- [ ] Docs / tooling

## Related issue

<!-- Closes #<issue number>, or "N/A" -->

## Testing

<!-- How was this tested? Check all that apply. -->

- [x] Tested manually in After Effects
- [ ] Unit tests added / updated
- [x] Existing tests pass (`yarn test`)

**After Effects version tested: 26**
**OS tested on: MacOS**

## Screenshots

<img width="658" height="607" alt="image" src="https://github.com/user-attachments/assets/d8c4539d-9f64-449d-9d35-d891622d0621" />

## Checklist

- [x] `yarn biome` passes (or `yarn biome:fix` was run)
- [x] `yarn build` completes without errors
- [x] No new TypeScript errors
