### PR TITLE
fix: allow 0 digit in pin input

### DIFF
--- a/plainly-plugin/src/ui/components/settings/PinInput.tsx
+++ b/plainly-plugin/src/ui/components/settings/PinInput.tsx
@@ -78,7 +78,7 @@ export function PinInput({
         pattern="[0-9]{1}"
         className="block w-8 text-center rounded-md bg-white/5 px-3 py-1 text-xs text-white outline outline-1 -outline-offset-1 outline-white/10 placeholder:text-gray-500 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-500"
         maxLength={1}
-        value={pin?.first || ''}
+        value={pin?.first ?? ''}
         onInput={(e) => changeDigit('first', e.currentTarget.value)}
         autoFocus={overlay}
       />
@@ -90,7 +90,7 @@ export function PinInput({
         pattern="[0-9]{1}"
         maxLength={1}
         className="block w-8 text-center rounded-md bg-white/5 px-3 py-1 text-xs text-white outline outline-1 -outline-offset-1 outline-white/10 placeholder:text-gray-500 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-500"
-        value={pin?.second || ''}
+        value={pin?.second ?? ''}
         onInput={(e) => changeDigit('second', e.currentTarget.value)}
       />
       <input
@@ -101,7 +101,7 @@ export function PinInput({
         pattern="[0-9]{1}"
         maxLength={1}
         className="block w-8 text-center rounded-md bg-white/5 px-3 py-1 text-xs text-white outline outline-1 -outline-offset-1 outline-white/10 placeholder:text-gray-500 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-500"
-        value={pin?.third || ''}
+        value={pin?.third ?? ''}
         onInput={(e) => changeDigit('third', e.currentTarget.value)}
       />
       <input
@@ -112,7 +112,7 @@ export function PinInput({
         pattern="[0-9]{1}"
         maxLength={1}
         className="block w-8 text-center rounded-md bg-white/5 px-3 py-1 text-xs text-white outline outline-1 -outline-offset-1 outline-white/10 placeholder:text-gray-500 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-500"
-        value={pin?.fourth || ''}
+        value={pin?.fourth ?? ''}
         onInput={(e) => changeDigit('fourth', e.currentTarget.value)}
       />
     </div>


### PR DESCRIPTION
## Summary
- `pin?.first || ''` (and the three other digits) in `PinInput.tsx` treated the number `0` as falsy, so typing `0` was stored internally but immediately rendered as empty.
- Switched to `??` so only `undefined` falls back to `''`.

## Test plan
- [x] Open the pin input (settings + overlay) and verify you can type `0` in each of the four positions.
- [x] Verify focus still advances to the next digit after entering `0`.
- [x] Verify a pin containing `0` digits (e.g. `1020`) round-trips correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)