### PR TITLE
fix(ci): use openssl legacy provider to verify certificate

### DIFF
--- a/.github/workflows/sign-extension.yml
+++ b/.github/workflows/sign-extension.yml
@@ -47,7 +47,8 @@ jobs:
         run: echo "${{ secrets.PLUGIN_CERTIFICATE_P12 }}" | base64 --decode > certificate.p12
 
       - name: Verify certificate
-        run: openssl pkcs12 -info -in certificate.p12 -noout -passin pass:${{ secrets.PLUGIN_CERTIFICATE_P12_PASSWORD }}
+        # -legacy: p12 uses RC2-40-CBC, moved to OpenSSL 3 legacy provider
+        run: openssl pkcs12 -legacy -info -in certificate.p12 -noout -passin pass:${{ secrets.PLUGIN_CERTIFICATE_P12_PASSWORD }}
 
       - name: Perform signing
         run: |


### PR DESCRIPTION
## Summary

macos-latest runner image now ships OpenSSL 3.x, which moved RC2-40-CBC to the legacy provider. The p12 is encrypted with pbeWithSHA1And40BitRC2-CBC, so verification failed with "digital envelope routines...unsupported".

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / internal improvement
- [ ] Dependency update
- [ ] Docs / tooling

## Related issue

<!-- Closes #<issue number>, or "N/A" -->

## Testing

<!-- How was this tested? Check all that apply. -->

- [ ] Tested manually in After Effects
- [ ] Unit tests added / updated
- [ ] Existing tests pass (`yarn test`)

**After Effects version tested:**
**OS tested on:**

## Screenshots

<!-- If this changes the UI, include before/after screenshots. -->

## Checklist

- [ ] `yarn biome` passes (or `yarn biome:fix` was run)
- [ ] `yarn build` completes without errors
- [ ] No new TypeScript errors
