### PR TITLE
fix: allow clearing name, description and tags in upload form

### DIFF
--- a/plainly-plugin/src/ui/components/form/UploadForm.tsx
+++ b/plainly-plugin/src/ui/components/form/UploadForm.tsx
@@ -104,13 +104,15 @@ export function UploadForm() {
       const projectName = inputs.projectName?.trim();
       projectName && formData.append('name', projectName);
 
-      const description = inputs.description?.trim();
-      description && formData.append('description', description);
+      // fields the user touched are always sent, empty included, so they can be cleared
+      if (inputs.description !== undefined) {
+        formData.append('description', inputs.description.trim());
+      }
 
-      const tagsSet = new Set(inputs.tags?.map((tag) => tag.trim()));
-      const tags = Array.from(tagsSet).filter((tag) => tag.length > 0);
-      if (tags.length > 0) {
-        for (const tag of tags) {
+      if (inputs.tags !== undefined) {
+        const tagsSet = new Set(inputs.tags.map((tag) => tag.trim()));
+        const tags = Array.from(tagsSet).filter((tag) => tag.length > 0);
+        for (const tag of tags.length > 0 ? tags : ['']) {
           formData.append('tags', tag);
         }
       }
@@ -303,10 +305,10 @@ export function UploadForm() {
 
         {editSelected ? (
           <Inputs
-            projectName={inputs.projectName || data?.name}
-            description={inputs.description || data?.description}
-            tags={inputs.tags || data?.attributes?.tags}
-            folder={inputs.folder || data?.attributes?.folder}
+            projectName={inputs.projectName ?? data?.name}
+            description={inputs.description ?? data?.description}
+            tags={inputs.tags ?? data?.attributes?.tags}
+            folder={inputs.folder ?? data?.attributes?.folder}
             onChange={handleChange}
           />
         ) : (


### PR DESCRIPTION
## Problem

When re-uploading an existing project, fields prefilled from the API could not be emptied:

1. Deleting the last character of the name or description immediately restored the original value — the only workaround was Ctrl+A then typing over it.
2. Even with the field emptied, the change was never persisted: the server kept the previous description/tags.

## Cause

1. `inputs.x || data?.x` — an empty string is falsy, so clearing the input fell straight back to the API value.
2. `description && formData.append(...)` (and the equivalent `tags.length > 0` guard) skipped falsy values, so a cleared field was simply absent from the request, which the API reads as "keep the current value".

## Fix

- `??` instead of `||`, so the API value only fills the input before the user touches it.
- Fields the user touched are always appended, empty included. Clearing the tag list sends a single empty `tags` part, which the API reads as an empty list (verified manually).

Name is unaffected by the second change (the input is `required`) and folder clears to `/` via the FolderPicker, so neither can reach the submit handler empty.

## Testing

Manually verified in the plugin: description and tags can now be emptied on re-upload and the platform reflects the cleared values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)